### PR TITLE
Gracefully handle empty audio generation

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -156,6 +156,11 @@ class Generator:
             ).unsqueeze(1)
             curr_pos = curr_pos[:, -1:] + 1
 
+        if not samples:
+            # Model terminated immediately; return an empty audio tensor instead of
+            # failing on ``torch.stack`` with an empty list.
+            return torch.zeros(0, device=self.device)
+
         audio = self._audio_tokenizer.decode(torch.stack(samples).permute(1, 2, 0)).squeeze(0).squeeze(0)
 
         # This applies an imperceptible watermark to identify audio as AI-generated.


### PR DESCRIPTION
## Summary
- Handle cases where the model ends generation immediately by returning an empty audio tensor

## Testing
- `python -m py_compile generator.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7f5b2070832ab1cb13a275569839